### PR TITLE
Small tidyup

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,1 +1,0 @@
-TERM=cygwin

--- a/PowerShell/terminal.ps1
+++ b/PowerShell/terminal.ps1
@@ -9,40 +9,31 @@ else {
 }
 
 if (Get-Module -ListAvailable -Name posh-git) {
-    Import-Module posh-git
+    Import-Module -Name posh-git
 }
 
 if (Get-Module -ListAvailable -Name Terminal-Icons) {
-    Import-Module Terminal-Icons
+    Import-Module -Name Terminal-Icons
 }
 
 if ((Get-Module -ListAvailable -Name PSFzf) -And (Get-Command "Fzf.exe" -ErrorAction SilentlyContinue)) {
-    Import-Module PSFzf -ArgumentList 'Ctrl+t', 'Ctrl+r'
+    Import-Module -Name PSFzf -ArgumentList 'Ctrl+t', 'Ctrl+r'
 }
 
 if (Get-Module -ListAvailable -Name z) {
-    Import-Module z
+    Import-Module -Name z
 }
 
 if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
-    Import-Module Microsoft.WinGet.Client
+    Import-Module -Name Microsoft.WinGet.Client
 }
 
 if (Get-Module -ListAvailable -Name Microsoft.WinGet.CommandNotFound) {
-    Import-Module Microsoft.WinGet.CommandNotFound
-}
-elseif (Get-Module -ListAvailable -Name WinGetCommandNotFound) {
-    Import-Module WinGetCommandNotFound
-}
-else {
-    $ModulePath = "C:\Program Files\PowerToys\WinUI3Apps\..\WinGetCommandNotFound.psd1"
-    if (Test-Path $ModulePath) {
-        Import-Module $ModulePath
-    }
+    Import-Module -Name Microsoft.WinGet.CommandNotFound
 }
 
 if (Get-Module -ListAvailable -Name gsudoModule) {
-    Import-Module gsudoModule
+    Import-Module -Name gsudoModule
     Set-Alias 'sudo' 'gsudo'
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -100,8 +100,7 @@ function Install-DotFiles {
 
     if (-not $IsCodespace) {
         $Dotfiles += @(
-            ".bash_profile",
-            ".bashrc"
+            ".bash_profile"
         )
     }
 


### PR DESCRIPTION
- Removes the `.bashrc` file and updates the install script accordingly
- Standardizes PowerShell Import-Module commands to use explicit -Name parameter
- Simplifies WinGet CommandNotFound module import logic by removing fallback options